### PR TITLE
Implemented Personal Route

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,3 +81,17 @@ export const updateTextboxValue = (textBoxName, textBoxInput) => {
 		input: textBoxInput
 	};
 };
+
+export const savePreferencesToStateOnReload = (savedInLocalStorage) => {
+	return {
+		type: 'SAVE_PREFERENCES_FROM_LOCAL_STORAGE',
+		savedInLocalStorage
+	};
+};
+
+export const restoreCustomisedSettings = (savedInLocalStorage) => {
+	return {
+		type: 'RESTORE_CUSTOMISED_SETTINGS',
+		savedInLocalStorage
+	};
+};

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -12,25 +12,55 @@ import { loadState } from '../helpers/localStorage';
 
 
 class AppRouter extends React.Component {
-	render(){
 
+
+
+	// componentDidMount(){
+	// 	loadState('news preferences');
+	// };
+
+
+	render(){
+		const defaultView =	<div>
+			<NavBar />
+			<Route exact path='/' component={Default} />
+			<Route path='/category/:category' component={Category} />
+			<Route path='/found' component={Found} />
+			<Route path='/customise' component={CustomiseContainer} />
+			<Route path='/personalised' component={PersonalView} />
+		</div>;
+
+		const personalView = 	<div>
+			<NavBar />
+			<Route exact path='/' component={PersonalView} />
+			<Route path='/category/:category' component={Category} />
+			<Route path='/found' component={Found} />
+			<Route path='/customise' component={CustomiseContainer} />
+			<Route path='/personalised' component={PersonalView} />
+		</div>;
+
+		const JSONfromLocalStorage = localStorage.getItem('news preferences');
+
+		const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
+
+		let displayed;
+
+		if(objectFromLocalStorage != null){
+			displayed = personalView;
+		} else {
+			displayed = defaultView;
+		}
 
 		return (
 			<Router>
 				<ScrollToTop>
-					<div>
-						<button><Link to='/personalised'>Personalised view </Link></button>
-						<NavBar />
-						<Route exact path='/' component={Default} />
-						<Route path='/category/:category' component={Category} />
-						<Route path='/found' component={Found} />
-						<Route path='/customise' component={CustomiseContainer} />
-						<Route path='/personalised' component={PersonalView} />
-					</div>
+					{displayed}
 				</ScrollToTop>
 			</Router>
+
 		);
 	}
+
 };
 
 

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -6,22 +6,52 @@ import Found from './Found';
 import CustomiseContainer from '../containers/CustomiseContainer';
 import NavBar from './NavBar';
 import ScrollToTop from './ScrollToTop';
+import PersonalView from './PersonalView';
 
 
-const AppRouter = () => (
-	<Router>
-		<ScrollToTop>
-			<div>
-				<NavBar />
-				<Route exact path='/' component={Default} />
-				<Route path='/category/:category' component={Category} />
-				<Route path='/found' component={Found} />
-				<Route path='/customise' component={CustomiseContainer} />
-			</div>
-		</ScrollToTop>
-	</Router>
+const AppRouter = () => {
 
-);
+	const defaultView =	<div>
+		<NavBar />
+		<Route exact path='/' component={Default} />
+		<Route path='/category/:category' component={Category} />
+		<Route path='/found' component={Found} />
+		<Route path='/customise' component={CustomiseContainer} />
+	</div>;
+
+	const personalView = 	<div>
+		<NavBar />
+		<Route exact path='/' component={PersonalView} />
+		<Route path='/category/:category' component={Category} />
+		<Route path='/found' component={Found} />
+		<Route path='/customise' component={CustomiseContainer} />
+	</div>;
+
+	const JSONfromLocalStorage = localStorage.getItem('news preferences');
+
+	const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
+
+	let displayed;
+
+	if(objectFromLocalStorage != null){
+		displayed = personalView;
+	} else {
+		displayed = defaultView;
+	}
+
+	return (
+		<Router>
+			<ScrollToTop>
+				{displayed}
+			</ScrollToTop>
+		</Router>
+
+	);
+};
+
+
+
+
 
 
 export default AppRouter;

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -12,53 +12,25 @@ import { loadState } from '../helpers/localStorage';
 
 
 class AppRouter extends React.Component {
-
-
-
-	// componentDidMount(){
-	// 	loadState('news preferences');
-	// };
-
-
 	render(){
-		const defaultView =	<div>
-			<NavBar />
-			<Route exact path='/' component={Default} />
-			<Route path='/category/:category' component={Category} />
-			<Route path='/found' component={Found} />
-			<Route path='/customise' component={CustomiseContainer} />
-		</div>;
 
-		const personalView = 	<div>
-			<NavBar />
-			<Route exact path='/' component={PersonalView} />
-			<Route path='/category/:category' component={Category} />
-			<Route path='/found' component={Found} />
-			<Route path='/customise' component={CustomiseContainer} />
-		</div>;
-
-		const JSONfromLocalStorage = localStorage.getItem('news preferences');
-
-		const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
-
-		let displayed;
-
-		if(objectFromLocalStorage != null){
-			displayed = personalView;
-		} else {
-			displayed = defaultView;
-		}
 
 		return (
 			<Router>
 				<ScrollToTop>
-					{displayed}
+					<div>
+						<button><Link to='/personalised'>Personalised view </Link></button>
+						<NavBar />
+						<Route exact path='/' component={Default} />
+						<Route path='/category/:category' component={Category} />
+						<Route path='/found' component={Found} />
+						<Route path='/customise' component={CustomiseContainer} />
+						<Route path='/personalised' component={PersonalView} />
+					</div>
 				</ScrollToTop>
 			</Router>
-
 		);
 	}
-
 };
 
 

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -8,45 +8,57 @@ import NavBar from './NavBar';
 import ScrollToTop from './ScrollToTop';
 import PersonalView from './PersonalView';
 
+import { loadState } from '../helpers/localStorage';
 
-const AppRouter = () => {
 
-	const defaultView =	<div>
-		<NavBar />
-		<Route exact path='/' component={Default} />
-		<Route path='/category/:category' component={Category} />
-		<Route path='/found' component={Found} />
-		<Route path='/customise' component={CustomiseContainer} />
-	</div>;
+class AppRouter extends React.Component {
 
-	const personalView = 	<div>
-		<NavBar />
-		<Route exact path='/' component={PersonalView} />
-		<Route path='/category/:category' component={Category} />
-		<Route path='/found' component={Found} />
-		<Route path='/customise' component={CustomiseContainer} />
-	</div>;
 
-	const JSONfromLocalStorage = localStorage.getItem('news preferences');
 
-	const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
+	// componentDidMount(){
+	// 	loadState('news preferences');
+	// };
 
-	let displayed;
 
-	if(objectFromLocalStorage != null){
-		displayed = personalView;
-	} else {
-		displayed = defaultView;
+	render(){
+		const defaultView =	<div>
+			<NavBar />
+			<Route exact path='/' component={Default} />
+			<Route path='/category/:category' component={Category} />
+			<Route path='/found' component={Found} />
+			<Route path='/customise' component={CustomiseContainer} />
+		</div>;
+
+		const personalView = 	<div>
+			<NavBar />
+			<Route exact path='/' component={PersonalView} />
+			<Route path='/category/:category' component={Category} />
+			<Route path='/found' component={Found} />
+			<Route path='/customise' component={CustomiseContainer} />
+		</div>;
+
+		const JSONfromLocalStorage = localStorage.getItem('news preferences');
+
+		const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
+
+		let displayed;
+
+		if(objectFromLocalStorage != null){
+			displayed = personalView;
+		} else {
+			displayed = defaultView;
+		}
+
+		return (
+			<Router>
+				<ScrollToTop>
+					{displayed}
+				</ScrollToTop>
+			</Router>
+
+		);
 	}
 
-	return (
-		<Router>
-			<ScrollToTop>
-				{displayed}
-			</ScrollToTop>
-		</Router>
-
-	);
 };
 
 

--- a/src/components/AppRouter.js
+++ b/src/components/AppRouter.js
@@ -21,40 +21,31 @@ class AppRouter extends React.Component {
 
 
 	render(){
-		const defaultView =	<div>
-			<NavBar />
-			<Route exact path='/' component={Default} />
-			<Route path='/category/:category' component={Category} />
-			<Route path='/found' component={Found} />
-			<Route path='/customise' component={CustomiseContainer} />
-			<Route path='/personalised' component={PersonalView} />
-		</div>;
-
-		const personalView = 	<div>
-			<NavBar />
-			<Route exact path='/' component={PersonalView} />
-			<Route path='/category/:category' component={Category} />
-			<Route path='/found' component={Found} />
-			<Route path='/customise' component={CustomiseContainer} />
-			<Route path='/personalised' component={PersonalView} />
-		</div>;
-
 		const JSONfromLocalStorage = localStorage.getItem('news preferences');
 
 		const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
 
-		let displayed;
+		let routeOnLoad;
 
 		if(objectFromLocalStorage != null){
-			displayed = personalView;
+			routeOnLoad = <Route exact path='/' component={PersonalView} />
+			;
 		} else {
-			displayed = defaultView;
+			routeOnLoad = <Route exact path='/' component={Default} />
+			;
 		}
 
 		return (
 			<Router>
 				<ScrollToTop>
-					{displayed}
+					<div>
+						<NavBar />
+						{routeOnLoad}
+						<Route path='/category/:category' component={Category} />
+						<Route path='/found' component={Found} />
+						<Route path='/customise' component={CustomiseContainer} />
+						<Route path='/personalised' component={PersonalView} />
+					</div>;
 				</ScrollToTop>
 			</Router>
 

--- a/src/components/Customise.js
+++ b/src/components/Customise.js
@@ -51,11 +51,11 @@ const Customise = ({toggleCheckbox, categoryPicker, savePreferences, updateTextb
 			<form
 				onSubmit={(event) => {
 					event.preventDefault();
-					let preferecesObject = {
+					let preferencesObject = {
 						categoryPicker,
 						textBox
 					};
-					savePreferences(preferecesObject);
+					savePreferences(preferencesObject);
 				}}>
 				{categorySelector}
 				{textInputs}

--- a/src/components/Customise.js
+++ b/src/components/Customise.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import categories from '../constants/categories';
 
-const Customise = ({toggleCheckbox, categoryPicker, savePreferences, updateTextbox, textBox}) => {
+const Customise = ({toggleCheckbox, categoryPicker, savePreferences, updateTextbox, textBox, history}) => {
 
 	// do NOT change words inside textInputsArray, as they are used as hooks for naming when setting state in reducer (see textBox object in updatePreferences reducer - the keys in that object and the words in textInputsArray need to match)
 	const textInputsArray = ['Interests', 'Ignore'];
@@ -56,6 +56,7 @@ const Customise = ({toggleCheckbox, categoryPicker, savePreferences, updateTextb
 						textBox
 					};
 					savePreferences(preferencesObject);
+					history.push('/personalised');
 				}}>
 				{categorySelector}
 				{textInputs}

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -2,69 +2,29 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Group from './Group';
 import categories from '../constants/categories';
+import {categoriesForRender} from '../helpers/categoriesForRender';
 
 class Feed extends React.Component {
 	constructor(props) {
     	super(props);
  	}
 	componentDidMount() {
+		console.log(categoriesForRender, this.props);
+		let preferredCategories = categoriesForRender(this.props.view, this.props);
 
+		console.log(preferredCategories);
 
-		const JSONfromLocalStorage = localStorage.getItem('news preferences');
-
-		const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
-
-		let preferredCategories = [];
-
-		if(objectFromLocalStorage != null){
-
-			Object.keys(objectFromLocalStorage.preferencesObject.categoryPicker).forEach(key => {
-				if(objectFromLocalStorage.preferencesObject.categoryPicker[key]){
-					preferredCategories.push(key);
-				}
-			});
-		}
-
-		if (preferredCategories.length > 0) {
-			preferredCategories.forEach((category) => {
-				this.props.getNews(category);
-			}, this);
-
-		} else {
-			categories.forEach((category) => {
-				this.props.getNews(category);
-			}, this);
-		}
-
+		preferredCategories.forEach((category) => {
+			this.props.getNews(category);
+		}, this);
 	};
 
 	render() {
+		let categoriesToRender = categoriesForRender(this.props.view, this.props);
 
-		const JSONfromLocalStorage = localStorage.getItem('news preferences');
+		console.log(categoriesToRender);
 
-		const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
-
-		let preferredCategories = [];
-
-		if(objectFromLocalStorage != null){
-
-			Object.keys(objectFromLocalStorage.preferencesObject.categoryPicker).forEach(key => {
-				if(objectFromLocalStorage.preferencesObject.categoryPicker[key]){
-					preferredCategories.push(key);
-				}
-			});
-		}
-
-		let categoriesShown;
-
-		if(preferredCategories.length > 0){
-			categoriesShown = preferredCategories;
-		} else {
-			categoriesShown = categories;
-		}
-		// this doesn't account for those who deliberately don't check any categories in preferences!
-
-		const groups = categoriesShown.map((category, i) => {
+		const groups = categoriesToRender.map((category, i) => {
 			return <Group
 				category={category}
 				data={this.props.news.news[category]}

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -9,6 +9,7 @@ class Feed extends React.Component {
  	}
 	componentDidMount() {
 
+
 		const JSONfromLocalStorage = localStorage.getItem('news preferences');
 
 		const objectFromLocalStorage =  JSON.parse(JSONfromLocalStorage);
@@ -17,8 +18,8 @@ class Feed extends React.Component {
 
 		if(objectFromLocalStorage != null){
 
-			Object.keys(objectFromLocalStorage.preferecesObject.categoryPicker).forEach(key => {
-				if(objectFromLocalStorage.preferecesObject.categoryPicker[key]){
+			Object.keys(objectFromLocalStorage.preferencesObject.categoryPicker).forEach(key => {
+				if(objectFromLocalStorage.preferencesObject.categoryPicker[key]){
 					preferredCategories.push(key);
 				}
 			});
@@ -47,8 +48,8 @@ class Feed extends React.Component {
 
 		if(objectFromLocalStorage != null){
 
-			Object.keys(objectFromLocalStorage.preferecesObject.categoryPicker).forEach(key => {
-				if(objectFromLocalStorage.preferecesObject.categoryPicker[key]){
+			Object.keys(objectFromLocalStorage.preferencesObject.categoryPicker).forEach(key => {
+				if(objectFromLocalStorage.preferencesObject.categoryPicker[key]){
 					preferredCategories.push(key);
 				}
 			});
@@ -86,7 +87,7 @@ class Feed extends React.Component {
 Feed.propTypes = {
 	getNews: PropTypes.func,
 	category: PropTypes.string,
-	data: PropTypes.array, 
+	data: PropTypes.array,
 	history: PropTypes.object,
 	searchResults: PropTypes.func,
 	categoryCollapse: PropTypes.bool,

--- a/src/components/Interests.js
+++ b/src/components/Interests.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Story from './Story';
+
+const Interests = (props) => {
+	const {interest} = props;
+
+
+
+	return (
+		<section className="interest">
+			<h3> INTEREST </h3>
+			{interest}
+		</section>
+	);
+
+};
+
+export default Interests;

--- a/src/components/PersonalView.js
+++ b/src/components/PersonalView.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Search from './Search';
+import FeedContainer from '../containers/FeedContainer';
+import Interests from './Interests';
+
+const PersonalView = () => (
+	<div>
+		<Search
+			searchResults={false}
+		/>
+		<FeedContainer
+			view='default'
+			categoryCollapse={false}
+			numberOfStories={5}
+		/>
+		<Interests />
+	</div>
+);
+
+export default PersonalView;

--- a/src/components/PersonalView.js
+++ b/src/components/PersonalView.js
@@ -9,7 +9,7 @@ const PersonalView = () => (
 			searchResults={false}
 		/>
 		<FeedContainer
-			view='default'
+			view='personalised'
 			categoryCollapse={false}
 			numberOfStories={5}
 		/>

--- a/src/containers/CustomiseContainer.js
+++ b/src/containers/CustomiseContainer.js
@@ -12,6 +12,7 @@ const getCheckboxState = state => {
 };
 
 const getTextBoxState = state =>{
+	console.log(state);
 	return state.updatePreferences.textBox;
 };
 
@@ -25,7 +26,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
 	toggleCheckbox : (category) => dispatch(updateCheckboxValue(category)),
 	updateTextbox : (textBoxName, texBoxInput) => dispatch(updateTextboxValue(textBoxName, texBoxInput)),
-	savePreferences: (preferecesObject) => dispatch(savePreferencesToLocalStorage({preferecesObject}))
+	savePreferences: (preferencesObject) => dispatch(savePreferencesToLocalStorage({preferencesObject}))
 });
 
 export default connect(

--- a/src/containers/CustomiseContainer.js
+++ b/src/containers/CustomiseContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import Customise from '../components/Customise';
 import {updateCheckboxValue, savePreferencesToLocalStorage, updateTextboxValue} from '../actions';
+import { withRouter } from 'react-router';
 
 const checkAndFetchLocalStorage = () => {
 	let preferencesFromMemory = localStorage.getItem('news preferences');
@@ -16,10 +17,11 @@ const getTextBoxState = state =>{
 	return state.updatePreferences.textBox;
 };
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
 	return {
 		categoryPicker : getCheckboxState(state),
-		textBox: getTextBoxState(state)
+		textBox: getTextBoxState(state),
+		ownProps
 	};
 };
 
@@ -29,7 +31,7 @@ const mapDispatchToProps = dispatch => ({
 	savePreferences: (preferencesObject) => dispatch(savePreferencesToLocalStorage({preferencesObject}))
 });
 
-export default connect(
+export default withRouter(connect(
 	mapStateToProps,
 	mapDispatchToProps
-)(Customise);
+)(Customise));

--- a/src/containers/FeedContainer.js
+++ b/src/containers/FeedContainer.js
@@ -8,6 +8,7 @@ const getNews = (state) => {
 	Object.keys(workingState.news).forEach(item => {
 		workingState.news[item] = state.news[item];
 	});
+	console.log(workingState);
 	return workingState;
 };
 

--- a/src/containers/FeedContainer.js
+++ b/src/containers/FeedContainer.js
@@ -15,6 +15,7 @@ const getNews = (state) => {
 const mapStateToProps = (state, ownProps) => {
 	return {
 		news : getNews(state),
+		savedPreferences: state.savePreferences.preferences.preferencesObject,
 		ownProps
 	};
 };

--- a/src/helpers/categoriesForRender.js
+++ b/src/helpers/categoriesForRender.js
@@ -1,0 +1,15 @@
+import categories from '../constants/categories';
+
+export const categoriesForRender = (view, properties) => {
+	let preferredCategories = [];
+	if (view === 'personalised') {
+		Object.keys(properties.savedPreferences.categoryPicker).forEach(key => {
+			if(properties.savedPreferences.categoryPicker[key]){
+				preferredCategories.push(key);
+			}
+		});
+	} else {
+		preferredCategories = categories;
+	}
+	return preferredCategories;
+};

--- a/src/helpers/localStorage.js
+++ b/src/helpers/localStorage.js
@@ -1,0 +1,20 @@
+export const loadState = (storageKey) => {
+	try {
+		const serialisedState = localStorage.getItem(storageKey);
+		if (serialisedState === null){
+			return undefined;
+		}
+		return JSON.parse(serialisedState);
+	} catch (err) {
+		return undefined;
+	}
+};
+
+export const saveState = (storageKey, stateToBeSaved) => {
+	try {
+		const serialisedState = JSON.stringify(stateToBeSaved);
+		localStorage.setItem(storageKey, serialisedState);
+	} catch (err) {
+		// Ignore write errors
+	};
+};

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,6 @@ const store = createStore(reducers, applyMiddleware(thunkMiddleware));
 const userPreferences = loadState('news preferences');
 
 if(userPreferences){
-	console.log('should only be here once prefs have been set');
-	console.log(userPreferences);
 	store.dispatch(savePreferencesToStateOnReload(userPreferences));
 	store.dispatch(restoreCustomisedSettings(userPreferences));
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,22 @@ import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import reducers from './reducers';
+import { loadState } from './helpers/localStorage';
+import { savePreferencesToStateOnReload, restoreCustomisedSettings } from './actions';
 
 const store = createStore(reducers, applyMiddleware(thunkMiddleware));
+
+const userPreferences = loadState('news preferences');
+
+if(userPreferences){
+	console.log('should only be here once prefs have been set');
+	console.log(userPreferences);
+	store.dispatch(savePreferencesToStateOnReload(userPreferences));
+	store.dispatch(restoreCustomisedSettings(userPreferences));
+};
+
+
+
 
 ReactDOM.render(
 	<Provider store={store}>

--- a/src/reducers/receiveNews.js
+++ b/src/reducers/receiveNews.js
@@ -11,6 +11,7 @@ const news = (state = initialState, action) => {
 		return Object.assign({}, state, {
 			[action.category]: action.news
 		});
+		break;
 	default:
 		return state;
 	};

--- a/src/reducers/savePreferences.js
+++ b/src/reducers/savePreferences.js
@@ -5,6 +5,11 @@ const savePreferences = (state = {}, action) => {
 		outputObject.preferences = Object.assign({}, action.preferences);
 		return outputObject;
 		break;
+	case 'SAVE_PREFERENCES_FROM_LOCAL_STORAGE':
+		let outputObject2 =  Object.assign({}, state);
+		outputObject2.preferences = Object.assign({}, action.savedInLocalStorage);
+		return outputObject2;
+		break;
 	default:
 		return state;
 	};

--- a/src/reducers/searchComponentFunctionality.js
+++ b/src/reducers/searchComponentFunctionality.js
@@ -15,6 +15,7 @@ const searchComponentFunctionality = (state = {
 			searchQueryInput: '',
 			mostRecentSearch: action.query
 		});
+		break;
 	default:
 		return state;
 	}

--- a/src/reducers/updatePreferences.js
+++ b/src/reducers/updatePreferences.js
@@ -23,6 +23,7 @@ const updatePreferences = (state = {
 			[action.category] : !state.categoryPicker[action.category]
 		});
 		return outputObject;
+		break;
 	case 'UPDATE_TEXTBOX_VALUE':
 		let outputObject2 = Object.assign({}, state);
 		outputObject2.textBox = Object.assign({},
@@ -31,6 +32,14 @@ const updatePreferences = (state = {
 			}
 		);
 		return outputObject2;
+		break;
+	case 'RESTORE_CUSTOMISED_SETTINGS':
+		let outputObject3 =  Object.assign({}, state);
+		console.log(action);
+		outputObject3.categoryPicker = Object.assign({}, action.savedInLocalStorage.preferencesObject.categoryPicker);
+		outputObject3.textBox = Object.assign({}, action.savedInLocalStorage.preferencesObject.textBox);
+		return outputObject3;
+		break;
 	default:
 		return state;
 	}


### PR DESCRIPTION
- user preferences now loaded into Store-source-of-truth on reload. 
- different routes used : default & personal - depending if user has customised their preferences
- category iterator moved to its own helper function

TODO:
- finish setting up the localStorage to match Dan Abramov's video
- load results per interest