### PR TITLE
fix(processLangFromBrowser): Allow for languages without a defined regional tag

### DIFF
--- a/BE/helpers/processLangFromBrowser.js
+++ b/BE/helpers/processLangFromBrowser.js
@@ -1,13 +1,13 @@
 const processLangFromBrowser = (acceptLangFromBrowser) => {
 	const lang = acceptLangFromBrowser.split(',')[0].split('-');
-	const primaryTag = lang[0];
-	const regionTag = lang[1];
+	const primaryTag = lang[0].toLowerCase();
+	const regionTag = lang.length > 1 ? lang[1].toLowerCase() : primaryTag;
 
 	const acceptedLangs = ['ae', 'ar', 'at', 'au', 'be', 'bg', 'br', 'ca', 'ch', 'cn', 'co', 'cu', 'cz', 'de', 'eg', 'fr', 'gb', 'gr', 'hk', 'hu', 'id', 'ie', 'il', 'in', 'it', 'jp', 'kr', 'lt', 'lv', 'ma', 'mx', 'my', 'ng', 'nl', 'no', 'nz', 'ph', 'pl', 'pt', 'ro', 'rs', 'ru', 'sa', 'se', 'sg', 'si', 'sk', 'th', 'tr', 'tw', 'ua', 'us', 've', 'za'];
 
 	let queryLang;
 
-	if (acceptedLangs.includes(regionTag.toLowerCase())) {
+	if (acceptedLangs.includes(regionTag)) {
 		queryLang = regionTag;
 	} else if (acceptedLangs.includes(primaryTag.toLowerCase())) {
 		queryLang = primaryTag;
@@ -15,7 +15,7 @@ const processLangFromBrowser = (acceptLangFromBrowser) => {
 		queryLang = 'gb';
 	}
 
-	return queryLang.toLowerCase();
+	return queryLang;
 };
 
 module.exports = {

--- a/tests/helpers/processLangFromBrowser.test.js
+++ b/tests/helpers/processLangFromBrowser.test.js
@@ -20,4 +20,10 @@ describe('processLangFromBrowser', () => {
 		const expectedOutcome = 'gb';
 		expect(processLangFromBrowser(langFromBrowser)).toEqual(expectedOutcome);
 	});
+
+	it('accepts languages without regionals', () => {
+		const langFromBrowser = 'pl'; // Polish
+		const expectedOutcome = 'pl';
+		expect(processLangFromBrowser(langFromBrowser)).toEqual(expectedOutcome);
+	});
 });


### PR DESCRIPTION
This change fixes a bug where if the browser defined `Accept-Language` without a regional tag (`en` for example, as opposed to `en-US` or `en-GB`), the code would fail and no news would be fetched from the source.